### PR TITLE
Keep website deploy from overwriting docs

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -45,6 +45,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         BRANCH: gh-pages
         FOLDER: page/__site
+        CLEAN: false
   build-docs:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
This PR adds a flag for the second website deploy workflow to prevent it from "cleaning" the docs from the `gh-pages` branch. Currently, the following lines appear in the second deploy action ([see log](https://github.com/AlgebraicJulia/Semagrams.jl/runs/3750735505?check_suite_focus=true)):
<img width="1009" alt="image" src="https://user-images.githubusercontent.com/19711695/135624831-36bf65a7-2bab-49f6-b419-04e624831a3a.png">

It appears that the `clean` option is on by default, causing this clearing out of the `gh-pages` branch. ([wiki](https://github.com/JamesIves/github-pages-deploy-action)).
<img width="886" alt="image" src="https://user-images.githubusercontent.com/19711695/135625087-0d3e168c-fa13-42a5-8145-862d60775605.png">


