### PR TITLE
Upgrade to Catlab v0.13

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -17,7 +17,7 @@ StructTypes = "856f2bd8-1eba-4b0a-8007-ebc267875bd4"
 WebIO = "0f1e0344-ec1d-5b48-a673-e5cf874b6c29"
 
 [compat]
-Catlab = "0.12"
+Catlab = "0.13"
 DefaultApplication = "1.0"
 JSExpr = "0.5"
 JSON = "0.21"

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -47,12 +47,12 @@ using Catlab.CategoricalAlgebra.FreeSchema
   is::Hom(I,S)
   ot::Hom(O,T)
   os::Hom(O,S)
-  N::Data
+  N::AttrType
   rate::Attr(T,N)
   concentration::Attr(S,N)
 end
 
-const ReactionNet = CSetType(TheoryReactionNet)
+@acset_type ReactionNet(TheoryReactionNet)
 ```
 
 and
@@ -66,7 +66,7 @@ and
   tgt::Hom(Wire,IPort)
 end
 
-const DPG = CSetType(TheoryDirectedPortGraph)
+@acset_type DPG(TheoryDirectedPortGraph)
 ```
 
 After making an acset, you must make a semagrams schema for the acset you made in step 1. The basic idea behind this is that you have to tell Semagrams.jl what role the objects in your acset play. Currently the three roles are

--- a/src/Data.jl
+++ b/src/Data.jl
@@ -118,18 +118,18 @@ function lookup_attachment(box_map::Dict{Int,Int},
   end
 end
 
-function attribute_type(::Type{T}, attr::Symbol) where {CD, AD, Ts, T <: AbstractACSet{CD, AD, Ts}}
-  Ts.parameters[Theories.codom_num(AD, attr)]
+function attribute_type(::Type{T}, attr::Symbol) where {S, Ts, T <: StructACSet{S,Ts}}
+  Ts.parameters[Theories.codom_num(S, attr)]
 end
 
-function attributes_from_strings(weights::Dict{Symbol, String}, ::Type{T}) where {T <: AbstractACSet}
+function attributes_from_strings(weights::Dict{Symbol, String}, ::Type{T}) where {T <: ACSet}
   types = Dict([attr => attribute_type(T, attr) for attr in keys(weights)]...)
   NamedTuple{(keys(types)...,),Tuple{values(types)...}}(
     [from_json(weights[attr],types[attr]) for attr in keys(weights)]
   )
 end
 
-function to_acset(ls::LocatedSemagramData, ::Type{T}) where {T <: AbstractACSet}
+function to_acset(ls::LocatedSemagramData, ::Type{T}) where {T <: ACSet}
   sd = ls.sg
   schema = sd.schema
   acs = T()

--- a/src/Examples.jl
+++ b/src/Examples.jl
@@ -10,7 +10,7 @@ export TheoryReactionNet, ReactionNet, ReactionNetSema,
   TheoryDDS, DDS, DDSSema,
   TheoryUWD, UWD, UWDSema
 
-using Catlab.Present, Catlab.CSetDataStructures
+using Catlab, Catlab.CategoricalAlgebra
 using JSExpr
 using ..Schema
 using ..Boxes
@@ -21,15 +21,15 @@ using ..Boxes
   is::Hom(I,S)
   ot::Hom(O,T)
   os::Hom(O,S)
-  N::Data
-  L::Data
+  N::AttrType
+  L::AttrType
   rate::Attr(T,N)
   concentration::Attr(S,N)
   species_label::Attr(S,L)
   transitions_label::Attr(T,L)
 end
 
-const ReactionNet = ACSetType(TheoryReactionNet)
+@acset_type ReactionNet(TheoryReactionNet, index=[:it,:is,:ot,:os])
 
 @semagramschema ReactionNetSema(TheoryReactionNet) begin
   @box S Circle label=:species_label
@@ -49,11 +49,12 @@ end
   src::Hom(Wire,OPort)
   tgt::Hom(Wire,IPort)
 
-  String::Data
+  String::AttrType
   label::Attr(Box,String)
 end
 
-const DirectedPortGraph = ACSetType(TheoryDirectedPortGraph)
+@acset_type DirectedPortGraph(TheoryDirectedPortGraph,
+                              index=[:ibox,:obox,:src,:tgt])
 
 @semagramschema DirectedPortGraphSema(TheoryDirectedPortGraph) begin
   @box Box Square label=:label
@@ -64,13 +65,13 @@ const DirectedPortGraph = ACSetType(TheoryDirectedPortGraph)
 end
 
 @present TheoryColoredDPG <: TheoryDirectedPortGraph begin
-  Color::Data
+  Color::AttrType
   iportcolor::Attr(IPort,Color)
   oportcolor::Attr(OPort,Color)
   wirecolor::Attr(Wire,Color)
 end
 
-const ColoredDPG = ACSetType(TheoryColoredDPG)
+@acset_type ColoredDPG(TheoryColoredDPG, index=[:ibox,:obox,:src,:tgt])
 
 color(attr) = js"weights => { return { stroke: weights[$attr] }; }"
 
@@ -91,13 +92,13 @@ end
   src::Hom(Wire,Port)
   tgt::Hom(Wire,Port)
 
-  Resistance::Data
+  Resistance::AttrType
   R::Attr(Wire, Resistance)
-  Voltage::Data
+  Voltage::AttrType
   V::Attr(Port, Voltage)
 end
 
-const CircuitGraph = ACSetType(TheoryCircuitGraph)
+@acset_type CircuitGraph(TheoryCircuitGraph, index=[:box,:src,:tgt])
 
 @semagramschema CircuitGraphSema(TheoryCircuitGraph) begin
   @box Box Circle
@@ -112,7 +113,7 @@ end
   next::Hom(X,X)
 end
 
-const DDS = ACSetType(TheoryDDS)
+@acset_type DDS(TheoryDDS)
 
 @semagramschema DDSSema(TheoryDDS) begin
   @box X Square
@@ -128,7 +129,7 @@ end
   outer_junction::Hom(OuterPort, Junction)
 end
 
-const UWD = ACSetType(TheoryUWD)
+@acset_type UWD(TheoryUWD, index=[:box,:junction,:outer_junction])
 
 @semagramschema UWDSema(TheoryUWD) begin
   @box Box Circle

--- a/src/UI.jl
+++ b/src/UI.jl
@@ -29,12 +29,12 @@ Contains:
 - `ws`, the schema of the semagram. This gets passed to typescript, and also
    tells us how to interpret the data that we are getting back from typescript.
 """
-struct Semagram{T <: AbstractACSet}
+struct Semagram{T <: ACSet}
   scope::Scope
   receiving::Observable{Dict{String,Any}}
   sending::Observable{Dict{String,Any}}
   exported::Observable{String}
-  function Semagram{T}(ls::LocatedSemagramData) where {T <: AbstractACSet}
+  function Semagram{T}(ls::LocatedSemagramData) where {T <: ACSet}
     try
       T()
     catch e
@@ -72,7 +72,7 @@ struct Semagram{T <: AbstractACSet}
   end
 end
 
-function Semagram{T}(s::SemagramSchema) where {T <: AbstractACSet}
+function Semagram{T}(s::SemagramSchema) where {T <: ACSet}
   ls = LocatedSemagramData(s)
   Semagram{T}(ls)
 end


### PR DESCRIPTION
I've updated Semagrams to use struct acsets.

The example notebooks still need to be updated.