### PR TITLE
Hotfix: comment out old wiringdiagrams app

### DIFF
--- a/scala/build.sc
+++ b/scala/build.sc
@@ -74,11 +74,11 @@ object apps extends Module {
   //   def artifactName = "semagrams-graph"
   // }
 
-  object wiringdiagrams extends SemagramsApp {
-    def desc = "simple wiring diagram editor"
+  // object wiringdiagrams extends SemagramsApp {
+  //   def desc = "simple wiring diagram editor"
 
-    def artifactName = "semagrams-wiringdiagrams"
-  }
+  //   def artifactName = "semagrams-wiringdiagrams"
+  // }
 
   object simplepetri extends SemagramsApp {
     def desc = "simple petri editor"


### PR DESCRIPTION
The new `dwd` app has much of the old functionality, and `wiringdiagrams` hadn't been updated for latest API changes.