### PR TITLE
Handle keyboard modifiers correctly

### DIFF
--- a/scala/core/src/keyboard.scala
+++ b/scala/core/src/keyboard.scala
@@ -8,13 +8,21 @@ enum KeyModifier:
   case Meta
   case Alt
 
-  def isSet(evt: KeyboardEvent) = this match {
-    case Ctrl  => evt.ctrlKey
-    case Shift => evt.shiftKey
-    case Meta  => evt.metaKey
-    case Alt   => evt.altKey
-  }
+  def isSet(evt: KeyboardEvent): Boolean =
+    if (evt.key == KeyModifier.asString(this)) {
+      evt.`type` == "keydown" || evt.`type` == "keypress"
+    } else {
+      this match {
+        case Ctrl  => evt.ctrlKey
+        case Shift => evt.shiftKey
+        case Meta  => evt.metaKey
+        case Alt   => evt.altKey
+      }
+    }
 
 object KeyModifier {
   val all = Set[KeyModifier](Ctrl, Shift, Meta, Alt)
+
+  val asString =
+    Map(Ctrl -> "Ctrl", Shift -> "Shift", Meta -> "Meta", Alt -> "Alt")
 }


### PR DESCRIPTION
This fixes a weird issue where `evt.ctrlKey` is false on the `keydown` event for `Ctrl` in Firefox.