### PR TITLE
Fix arrow rendering regressions

### DIFF
--- a/scala/apps/simplepetri/src/Main.scala
+++ b/scala/apps/simplepetri/src/Main.scala
@@ -19,7 +19,6 @@ import ACSet._
   *   - [X] Janky automatic layout
   *   - [X] Fix focus bug (can't figure out)
   *   - Write help popup
-  *   - Generate equations
   *   - JSON export
   */
 
@@ -215,9 +214,6 @@ object Main {
 
     def run(es: EditorState, init: Option[String]): IO[Unit] = {
       for {
-        // initg <- IO(init
-        //               .map(s => petriFromCLJson(read[catlab.ACSet](s)))
-        //               .getOrElse(Petri()))
         initg <- IO(Petri())
         sprungg <- IO(
           springLayoutPetri(

--- a/scala/core/src/sprites/ACSetEntitySources.scala
+++ b/scala/core/src/sprites/ACSetEntitySources.scala
@@ -67,7 +67,7 @@ def edgeProps(
   val nd = t
     .flatMap(findBoundary(_, m, dir * rot.cong))
     .getOrElse(tpos)
-  PropMap() + (Start, spos) + (End, tpos)
+  PropMap() + (Start, start) + (End, nd)
 }
 
 /** Like [[ACSetEntitySource]], but then also computes the edge properties using

--- a/scala/core/src/sprites/Arrow.scala
+++ b/scala/core/src/sprites/Arrow.scala
@@ -32,8 +32,9 @@ case class Arrow(defaults: PropMap) extends Sprite {
   def curvedPath(s: Complex, e: Complex, bend: Double): Seq[Path.Element] = {
     import Path.Element._
     val rot = Complex(0, bend).exp
-    val cs = rot * (s * (-1 / 4) + e * (1 / 4)) + s
-    val ce = rot.cong * (s * (1 / 4) + e * (-1 / 4)) + e
+    val λ = 1.0 / 4
+    val cs = rot * (λ * (e - s)) + s
+    val ce = rot.cong * (λ * (s - e)) + e
     Seq(MoveTo(s), Cubic(cs, ce, e))
   }
 

--- a/scala/core/src/sprites/Rect.scala
+++ b/scala/core/src/sprites/Rect.scala
@@ -74,8 +74,9 @@ case class Rect(props: PropMap) extends Sprite {
 
   override def boundaryPt(_subent: Entity, data: ACSet, dir: Complex) = {
     // Normalize to first quadrant
-    val (_, boxdims) = geom(props ++ data.props)
-    val os = (props ++ data.props)(OuterSep)
+    val pm = props ++ data.props
+    val (_, boxdims) = geom(pm)
+    val os = (pm)(OuterSep)
     val dims = Complex(boxdims.x + 2 * os, boxdims.y + 2 * os)
     val q1dir = Complex(dir.x.abs, dir.y.abs)
     val q1pt = if (q1dir.x == 0) {
@@ -93,7 +94,8 @@ case class Rect(props: PropMap) extends Sprite {
         dims.y / 2
       )
     }
-    Some(Complex(q1pt.x * dir.x.sign, q1pt.y * dir.y.sign) + data.props(Center))
+    val pt = Complex(q1pt.x * dir.x.sign, q1pt.y * dir.y.sign) + pm(Center)
+    Some(pt)
   }
 
   override def bbox(_subent: Entity, data: ACSet) = {


### PR DESCRIPTION
There were some arrow rendering regressions that slipped in, related to calculating the bending and positioning of arrows on boundaries.